### PR TITLE
task-runner: Add PlaybackRecordingID

### DIFF
--- a/api.go
+++ b/api.go
@@ -222,12 +222,12 @@ type (
 	}
 
 	AssetSpec struct {
-		Name                       string          `json:"name,omitempty"`
-		Type                       string          `json:"type"`
-		Size                       uint64          `json:"size"`
-		Hash                       []AssetHash     `json:"hash"`
-		VideoSpec                  *AssetVideoSpec `json:"videoSpec,omitempty"`
-		PlaybackRecordingSessionID string          `json:"playbackRecordingSessionId,omitempty"`
+		Name                string          `json:"name,omitempty"`
+		Type                string          `json:"type"`
+		Size                uint64          `json:"size"`
+		Hash                []AssetHash     `json:"hash"`
+		VideoSpec           *AssetVideoSpec `json:"videoSpec,omitempty"`
+		PlaybackRecordingID string          `json:"playbackRecordingId,omitempty"`
 	}
 
 	AssetHash struct {

--- a/api.go
+++ b/api.go
@@ -222,11 +222,12 @@ type (
 	}
 
 	AssetSpec struct {
-		Name      string          `json:"name,omitempty"`
-		Type      string          `json:"type"`
-		Size      uint64          `json:"size"`
-		Hash      []AssetHash     `json:"hash"`
-		VideoSpec *AssetVideoSpec `json:"videoSpec,omitempty"`
+		Name                       string          `json:"name,omitempty"`
+		Type                       string          `json:"type"`
+		Size                       uint64          `json:"size"`
+		Hash                       []AssetHash     `json:"hash"`
+		VideoSpec                  *AssetVideoSpec `json:"videoSpec,omitempty"`
+		PlaybackRecordingSessionID string          `json:"playbackRecordingSessionId,omitempty"`
 	}
 
 	AssetHash struct {


### PR DESCRIPTION
https://github.com/livepeer/task-runner/pull/16

Add PlaybackRecordingSessionID to AssetSpec

Should we be using `omitempty` here? 

Did not use camelCase for `ID` suffix, saw some mixed conventions in use.