### PR TITLE
Add NFTMetadataTemplate field to export task params

### DIFF
--- a/api.go
+++ b/api.go
@@ -52,6 +52,13 @@ const (
 	RecordingStatusReady   = "ready"
 )
 
+type NFTMetadataTemplate string
+
+const (
+	NFTMetadataTemplatePlayer NFTMetadataTemplate = "player" // default
+	NFTMetadataTemplateFile   NFTMetadataTemplate = "file"
+)
+
 type (
 	// Object with all options given to Livepeer API
 	ClientOptions struct {
@@ -199,7 +206,8 @@ type (
 				APIKey    string `json:"apiKey,omitempty"`
 				APISecret string `json:"apiSecret,omitempty"`
 			} `json:"pinata,omitempty"`
-			NFTMetadata map[string]interface{} `json:"nftMetadata,omitempty"`
+			NFTMetadataTemplate `json:"nftMetadataTemplate,omitempty"`
+			NFTMetadata         map[string]interface{} `json:"nftMetadata,omitempty"`
 		} `json:"ipfs,omitempty"`
 	}
 


### PR DESCRIPTION
This will be necessary for the `task-runner` to create different kinds of NFT metadata. 

Right now the options are to create an NFT either with a player or with the raw file, but it will
be necessary for supporting the Lens publications NFTs as well. For context: [[design doc]](https://www.notion.so/livepeer/Lens-Integration-Engineering-Spec-e756c036e6c741de97d8e9ef1c351e84#90373644024348108d2852ecaa21aa6f)

This is related to https://github.com/livepeer/task-runner/issues/33