### PR TITLE
api: Fix push segment timeout and add retries

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,5 +1,4 @@
-// Package livepeer API
-package lp_api
+package api
 
 import (
 	"bytes"

--- a/api.go
+++ b/api.go
@@ -1026,7 +1026,7 @@ func (lapi *Client) PushSegment(sid string, seqNo int, dur time.Duration, segDat
 			return nil, fmt.Errorf("no broadcasters available")
 		}
 	}
-	timeout := 2*time.Second + 4*dur
+	timeout := 3*time.Second + 3*dur
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	urlToUp := fmt.Sprintf("%s/live/%s/%d.ts", lapi.broadcasters[0], sid, seqNo)

--- a/api.go
+++ b/api.go
@@ -919,11 +919,18 @@ func (lapi *Client) GetObjectStore(id string) (*ObjectStore, error) {
 	return &os, nil
 }
 
-func Timedout(e error) bool {
-	t, ok := e.(interface {
+func Timedout(err error) bool {
+	if err == nil {
+		return false
+	}
+	var terr interface {
 		Timeout() bool
-	})
-	return ok && t.Timeout() || (e != nil && strings.Contains(e.Error(), "Client.Timeout"))
+	}
+	if errors.As(err, &terr) && terr.Timeout() {
+		return true
+	}
+	errMsg := strings.ToLower(err.Error())
+	return strings.Contains(errMsg, "client.timeout")
 }
 
 func (lapi *Client) newRequest(method, url string, bodyObj interface{}) (*http.Request, error) {

--- a/api.go
+++ b/api.go
@@ -1,5 +1,5 @@
 // Package livepeer API
-package livepeerAPI
+package lp_api
 
 import (
 	"bytes"

--- a/api.go
+++ b/api.go
@@ -12,7 +12,6 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
-	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -1044,17 +1043,12 @@ func (lapi *Client) PushSegment(sid string, seqNo int, dur time.Duration, segDat
 	postStarted := time.Now()
 	resp, err := pushSegmentHTTPClient.Do(req)
 	postTook := time.Since(postStarted)
-	var timedout bool
 	var status string
-	if err != nil {
-		uerr := err.(*url.Error)
-		timedout = uerr.Timeout()
-	}
 	if resp != nil {
 		status = resp.Status
 	}
 	glog.V(DEBUG).Infof("Post segment manifest=%s seqNo=%d dur=%s took=%s timed_out=%v status='%v' err=%v",
-		sid, seqNo, dur, postTook, timedout, status, err)
+		sid, seqNo, dur, postTook, Timedout(err), status, err)
 	if err != nil {
 		return nil, err
 	}

--- a/api.go
+++ b/api.go
@@ -1015,9 +1015,12 @@ func (lapi *Client) PushSegment(sid string, seqNo int, dur time.Duration, segDat
 			return nil, fmt.Errorf("no broadcasters available")
 		}
 	}
+	timeout := 2*time.Second + 4*dur
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 	urlToUp := fmt.Sprintf("%s/live/%s/%d.ts", lapi.broadcasters[0], sid, seqNo)
 	body := bytes.NewReader(segData)
-	req, err := http.NewRequest("POST", urlToUp, body)
+	req, err := http.NewRequestWithContext(ctx, "POST", urlToUp, body)
 	if err != nil {
 		return nil, err
 	}

--- a/api.go
+++ b/api.go
@@ -35,11 +35,14 @@ const (
 // ErrNotExists returned if receives a 404 error from the API
 var ErrNotExists = errors.New("not found")
 
-const httpTimeout = 4 * time.Second
 const setActiveTimeout = 1500 * time.Millisecond
 
 var defaultHTTPClient = &http.Client{
-	Timeout: httpTimeout,
+	Timeout: 4 * time.Second,
+}
+
+var pushSegmentHTTPClient = &http.Client{
+	Timeout: 2 * time.Minute,
 }
 
 var hostName, _ = os.Hostname()
@@ -1013,8 +1016,7 @@ func (lapi *Client) PushSegment(sid string, seqNo int, dur time.Duration, segDat
 		}
 	}
 	urlToUp := fmt.Sprintf("%s/live/%s/%d.ts", lapi.broadcasters[0], sid, seqNo)
-	var body io.Reader
-	body = bytes.NewReader(segData)
+	body := bytes.NewReader(segData)
 	req, err := http.NewRequest("POST", urlToUp, body)
 	if err != nil {
 		return nil, err
@@ -1026,7 +1028,7 @@ func (lapi *Client) PushSegment(sid string, seqNo int, dur time.Duration, segDat
 	}
 
 	postStarted := time.Now()
-	resp, err := lapi.httpClient.Do(req)
+	resp, err := pushSegmentHTTPClient.Do(req)
 	postTook := time.Since(postStarted)
 	var timedout bool
 	var status string

--- a/api.go
+++ b/api.go
@@ -1004,6 +1004,17 @@ func (lapi *Client) doRequest(method, url, resourceType, metricName string, inpu
 	return json.Unmarshal(b, output)
 }
 
+// PushSegmentR pushes a segment with retries
+func (lapi *Client) PushSegmentR(sid string, seqNo int, dur time.Duration, segData []byte, resolution string) (transcoded [][]byte, err error) {
+	for try := 1; try <= 3; try++ {
+		transcoded, err = lapi.PushSegment(sid, seqNo, dur, segData, resolution)
+		if err == nil || !Timedout(err) {
+			return
+		}
+	}
+	return
+}
+
 func (lapi *Client) PushSegment(sid string, seqNo int, dur time.Duration, segData []byte, resolution string) ([][]byte, error) {
 	var err error
 	if len(lapi.broadcasters) == 0 {


### PR DESCRIPTION
This is to fix the timeout used for the `PushSegment` API call, which was currently using
the very low default of ~4 seconds. 

Instead of that, created a custom client for the push segment, with a much higher timeout
of 2 minutes, and setup a custom timeout logic depending on the segment duration.

Also created a `PushSegmentR` version of the function which retries the transcoding up to
3 times in case of timeouts.

This implements https://github.com/livepeer/task-runner/issues/32