### PR TITLE
workflow: Add github actions to CI pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,22 @@
+name: Create release on github
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: match-tag
+        with:
+          text: ${{ github.ref_name }}
+          regex: '^v([0-9]+\.\d+\.\d+)$'
+
+      - name: Release to github
+        uses: softprops/action-gh-release@v1
+        if: ${{ steps.match-tag.outputs.match != '' }}
+        with:
+          generate_release_notes: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,62 @@
+name: Trigger test suite
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Test the livepeer-box project
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          # Check https://github.com/livepeer/go-livepeer/pull/1891
+          # for ref value discussion
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up go
+        id: go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+
+      - name: Cache go modules
+        id: cache-go-mod
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Install go modules
+        if: steps.cache-go-mod.outputs.cache-hit != 'true'
+        run: go mod download
+
+      - name: go fmt
+        run: |
+          go fmt ./...
+          git diff --exit-code
+
+      # - name: Run Revive Action by building from repository
+      #   uses: morphy2k/revive-action@v2
+      #   with:
+      #     config: config.toml
+
+      - name: misspell
+        uses: reviewdog/action-misspell@v1
+
+      - name: Run tests with coverage
+        run: go test ./... -race -covermode=atomic -coverprofile=coverage.out
+
+      - name: Upload coverage reports
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.out
+          name: go-api-client
+          verbose: true

--- a/api.go
+++ b/api.go
@@ -778,7 +778,7 @@ func (lapi *Client) SetActiveR(id string, active bool, startedAt time.Time) (boo
 				apiTry++
 				continue
 			}
-			glog.Errorf("Fatal error calling API /setactive id=%s active=%s err=%v", id, active, err)
+			glog.Errorf("Fatal error calling API /setactive id=%s active=%t err=%v", id, active, err)
 		}
 		return ok, err
 	}
@@ -816,7 +816,7 @@ func (lapi *Client) SetActive(id string, active bool, startedAt time.Time) (bool
 	defer resp.Body.Close()
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		glog.Errorf("id=%s/setactive Error set active (body) %v", err)
+		glog.Errorf("id=%s/setactive Error set active (body) %v", id, err)
 		lapi.metrics.APIRequest("set_active", 0, err)
 		return true, err
 	}


### PR DESCRIPTION
This should create prettier release logs on new tag pushes at <https://github.com/livepeer/go-api-client/releases>.