### PR TITLE
api: added tus config & fix tus

### DIFF
--- a/api.go
+++ b/api.go
@@ -1029,11 +1029,8 @@ func (lapi *Client) UploadAsset(ctx context.Context, url string, file io.Reader)
 
 func (lapi *Client) ResumableUpload(url string, file *os.File) error {
 
-	config := &tus.Config{
-		ChunkSize:           8 * 1024 * 1024,
-		Resume:              false,
-		OverridePatchMethod: false,
-	}
+	config := tus.DefaultConfig()
+	config.ChunkSize = 8 * 1024 * 1024 // 8MB
 
 	client, err := tus.NewClient(url, config)
 	if err != nil {

--- a/api.go
+++ b/api.go
@@ -1027,8 +1027,8 @@ func (lapi *Client) UploadAsset(ctx context.Context, url string, file io.Reader)
 	return nil
 }
 
+// Temporary function while waiting for go-api-client to get fixed
 func (lapi *Client) ResumableUpload(url string, file *os.File) error {
-
 	config := tus.DefaultConfig()
 	config.ChunkSize = 8 * 1024 * 1024 // 8MB
 

--- a/api.go
+++ b/api.go
@@ -1028,7 +1028,14 @@ func (lapi *Client) UploadAsset(ctx context.Context, url string, file io.Reader)
 }
 
 func (lapi *Client) ResumableUpload(url string, file *os.File) error {
-	client, err := tus.NewClient(url, nil)
+
+	config := &tus.Config{
+		ChunkSize:           8 * 1024 * 1024,
+		Resume:              false,
+		OverridePatchMethod: false,
+	}
+
+	client, err := tus.NewClient(url, config)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Apparently S3 multipart limits supports >5MB chunk size, so this is why 2 * 1024 * 1024 was failing