### PR TITLE
api: Add retries to ALL requests

### DIFF
--- a/api.go
+++ b/api.go
@@ -31,10 +31,12 @@ const (
 	INSANE2  = 14
 )
 
-// ErrNotExists returned if receives a 404 error from the API
-var ErrNotExists = errors.New("not found")
-
-const setActiveTimeout = 1500 * time.Millisecond
+var (
+	// ErrNotExists returned if receives a 404 error from the API
+	ErrNotExists = errors.New("not found")
+	// ErrRateLimited returned if receives a 429 error from the API
+	ErrRateLimited = errors.New("rate limited")
+)
 
 var defaultHTTPClient = &http.Client{
 	Timeout: 4 * time.Second,
@@ -1236,6 +1238,8 @@ func checkResponseError(resp *http.Response) error {
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		return ErrNotExists
+	} else if resp.StatusCode == http.StatusTooManyRequests {
+		return ErrRateLimited
 	}
 	var errResp struct {
 		Errors []string `json:"errors"`

--- a/api.go
+++ b/api.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -492,10 +491,10 @@ func GeolocateAPIServer() (string, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, _ := io.ReadAll(resp.Body)
 		return "", fmt.Errorf("status error contacting Livepeer API server (%s) status %d body: %s", livepeerAPIGeolocateURL, resp.StatusCode, string(b))
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("error geolocating Livepeer API server (%s): %w", livepeerAPIGeolocateURL, err)
 	}
@@ -1076,7 +1075,7 @@ func (lapi *Client) doRequestHeadersOnce(method, url, resourceType, metricName s
 		return resp.Header, err
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		glog.Errorf("Error reading Livepeer API response body resource=%s method=%s url=%s error=%q", resourceType, method, url, err)
 		lapi.metrics.APIRequest(metricName, 0, err)
@@ -1181,7 +1180,7 @@ func (lapi *Client) PushSegment(sid string, seqNo int, dur time.Duration, segDat
 					glog.Infof("Header '%s': '%s'", k, v)
 				}
 			}
-			body, merr := ioutil.ReadAll(p)
+			body, merr := io.ReadAll(p)
 			if merr != nil {
 				glog.Errorf("error reading body manifest=%s seqNo=%d err=%v", sid, seqNo, merr)
 				err = merr
@@ -1233,7 +1232,7 @@ func checkResponseError(resp *http.Response) error {
 	if isSuccessStatus(resp.StatusCode) {
 		return nil
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	glog.V(logs.VERBOSE).Infof("Status error from Livepeer API method=%s url=%s status=%d body=%q", resp.Request.Method, resp.Request.URL, resp.StatusCode, string(body))
 	if err != nil {
 		return fmt.Errorf("failed reading error response (%s): %w", resp.Status, err)

--- a/api.go
+++ b/api.go
@@ -752,9 +752,12 @@ func (lapi *Client) getStream(url, metricName string) (*Stream, error) {
 	return stream, nil
 }
 
-func (lapi *Client) GetTask(id string) (*Task, error) {
+func (lapi *Client) GetTask(id string, strongConsistency bool) (*Task, error) {
 	var task Task
 	url := fmt.Sprintf("%s/api/task/%s", lapi.chosenServer, id)
+	if strongConsistency {
+		url += "?strongConsistency=1"
+	}
 	if err := lapi.getJSON(url, "task", "", &task); err != nil {
 		return nil, err
 	}
@@ -897,9 +900,12 @@ func (lapi *Client) GetMultistreamTargetR(id string) (*MultistreamTarget, error)
 	}
 }
 
-func (lapi *Client) GetAsset(id string) (*Asset, error) {
+func (lapi *Client) GetAsset(id string, strongConsistency bool) (*Asset, error) {
 	var asset Asset
 	url := fmt.Sprintf("%s/api/asset/%s", lapi.chosenServer, id)
+	if strongConsistency {
+		url += "?strongConsistency=1"
+	}
 	if err := lapi.getJSON(url, "asset", "", &asset); err != nil {
 		return nil, err
 	}

--- a/api.go
+++ b/api.go
@@ -1026,14 +1026,6 @@ func (lapi *Client) newRequest(method, url string, bodyObj interface{}) (*http.R
 	return req, err
 }
 
-func (lapi *Client) getRequest(url string) *http.Request {
-	req, err := lapi.newRequest("GET", url, nil)
-	if err != nil {
-		glog.Fatal(err)
-	}
-	return req
-}
-
 func (lapi *Client) getJSON(url, resourceType, metricName string, output interface{}) error {
 	return lapi.doRequest("GET", url, resourceType, metricName, nil, output)
 }

--- a/api.go
+++ b/api.go
@@ -978,9 +978,6 @@ func isRetriable(err error) bool {
 	if err == nil {
 		return false
 	}
-	if Timedout(err) {
-		return true
-	}
 	return Timedout(err) ||
 		strings.HasPrefix(err.Error(), "request failed with status 5") // 5xx status code
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/livepeer/go-api-client
 
-go 1.16
+go 1.19
 
 require (
 	github.com/eventials/go-tus v0.0.0-20220610120217-05d0564bb571 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/livepeer/go-api-client
 
-go 1.19
+go 1.16
 
 require (
 	github.com/eventials/go-tus v0.0.0-20220610120217-05d0564bb571 // indirect


### PR DESCRIPTION
That's it. Kind of a lot of changes, but it's basically:
 - Create the common retry logic in `doRequestHeaders` which is called by `doRequest`
 - Replace all custom http client calls with one of the helpers (`doRequest` or `getJSON`) which end up calling that func