### PR TITLE
api: Fix /setactive API error handling

### DIFF
--- a/api.go
+++ b/api.go
@@ -771,9 +771,8 @@ func (lapi *Client) SetActive(id string, active bool, startedAt time.Time) (bool
 	if !startedAt.IsZero() {
 		req.StartedAt = startedAt.UnixNano() / int64(time.Millisecond)
 	}
-	var res json.RawMessage
-	err := lapi.doRequest("PUT", u, "stream", "set_active", req, &res)
-	glog.Infof("Ran setactive request id=%s request=%+v response=%q error=%q", id, req, res, err)
+	err := lapi.doRequest("PUT", u, "stream", "set_active", req, nil)
+	glog.Infof("Ran setactive request id=%s request=%+v error=%q", id, req, err)
 	if err != nil {
 		lapi.metrics.APIRequest("set_active", 0, err)
 		return false, err

--- a/api.go
+++ b/api.go
@@ -1340,11 +1340,6 @@ func checkResponseError(resp *http.Response) error {
 	if err != nil {
 		return fmt.Errorf("failed reading error response (%s): %w", resp.Status, err)
 	}
-	if resp.StatusCode == http.StatusNotFound {
-		return ErrNotExists
-	} else if resp.StatusCode == http.StatusTooManyRequests {
-		return ErrRateLimited
-	}
 	return newHTTPStatusError(resp.StatusCode, body)
 }
 


### PR DESCRIPTION
2 main things:
 - Stop trying to parse the response on successful cases. There is no body and it only leads to a client error when the server actually succeeded.
 - Handle 404 and 403 response errors and block the stream from starting (by returning !ok)