### PR TITLE
asset-file: added spec to AssetFile

### DIFF
--- a/api.go
+++ b/api.go
@@ -394,7 +394,7 @@ type (
 	}
 
 	AssetFileSpec struct {
-		Size string `json:"size"`
+		Size int `json:"size"`
 	}
 
 	AssetHash struct {

--- a/api.go
+++ b/api.go
@@ -388,8 +388,13 @@ type (
 	}
 
 	AssetFile struct {
-		Type string `json:"type"`
-		Path string `json:"path"`
+		Type string        `json:"type"`
+		Path string        `json:"path"`
+		Spec AssetFileSpec `json:"spec,omitempty"`
+	}
+
+	AssetFileSpec struct {
+		Size string `json:"size"`
 	}
 
 	AssetHash struct {


### PR DESCRIPTION
Added `spec` field to AssetFile to store the size of output mp4 renditions.
Can be expanded later with additional probe data incoming from Catalyst